### PR TITLE
chore: drop un-necessary urllib3 dep

### DIFF
--- a/recipe/001_setup_urllib3.patch
+++ b/recipe/001_setup_urllib3.patch
@@ -1,0 +1,11 @@
+--- box-sdk-gen-0.4.0.orig/setup.py	2024-02-14 08:38:33.776913585 -0600
++++ box-sdk-gen-0.4.0/setup.py	2024-02-14 08:38:47.847264689 -0600
+@@ -4,7 +4,7 @@
+ 
+ 
+ def main():
+-    install_requires = ['requests', 'requests_toolbelt', 'urllib3<2']
++    install_requires = ['requests', 'requests_toolbelt']
+     tests_require = ['pytest', 'pytest-timeout', 'pytest-cov']
+     dev_requires = ['tox']
+     jwt_requires = ['pyjwt>=1.7.0', 'cryptography>=3']

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -24,7 +24,6 @@ requirements:
     - pyjwt >=1.7.0
     - requests
     - requests-toolbelt
-    - urllib3 <2
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,8 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/box-sdk-gen-{{ version }}.tar.gz
   sha256: e49fe92d2e1feccfd2bbbeefdc7558d4ed97cfb33c77226bea61435c7e47a86b
+  patches:
+    - 001_setup_urllib3.patch
 
 build:
   noarch: python


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
*  Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Upstream confirmed this dep is un-necessary.